### PR TITLE
Undo USB setup before starting sketch

### DIFF
--- a/Caterina.c
+++ b/Caterina.c
@@ -90,6 +90,9 @@ void StartSketch(void)
 	TCNT1H = 0;		// 16-bit write to TCNT1 requires high byte be written first
 	TCNT1L = 0;
 	
+	/* Undo USB setup */
+	USB_Disable();
+	
 	/* Relocate the interrupt vector table to the application section */
 	MCUCR = (1 << IVCE);
 	MCUCR = 0;


### PR DESCRIPTION
This is an attempt to address Issue #2.

I have not tested this yet, but I intend to. I'm making this pull request so that the code can be reviewed.